### PR TITLE
more fixes

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -135,6 +135,7 @@ New features
       CASSANDRA-20102 adds a subset of the SQL99 (binary) string functions: "octet_length" defined on all types 
       and "length" defined on UTF8 strings. See CASSANDRA-20102 for more information.
     - New functions `format_bytes` and `format_time` were added. See CASSANDRA-19546.
+    - It is possible to use Async-profiler for various profiling scenarios. See CASSANDRA-20854.
 
 Upgrading
 ---------

--- a/doc/modules/cassandra/nav.adoc
+++ b/doc/modules/cassandra/nav.adoc
@@ -112,6 +112,7 @@
 **** xref:cassandra:managing/operating/password_validation.adoc[Password validation]
 **** xref:cassandra:managing/operating/role_name_generation.adoc[Role name generation]
 **** xref:cassandra:managing/operating/onboarding-to-accord.adoc[]
+**** xref:cassandra:managing/operating/async-profiler.adoc[]
 *** xref:cassandra:managing/tools/index.adoc[Tools]
 **** xref:cassandra:managing/tools/cqlsh.adoc[cqlsh: the CQL shell]
 **** xref:cassandra:managing/tools/nodetool/nodetool.adoc[nodetool]

--- a/doc/modules/cassandra/pages/managing/operating/async-profiler.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/async-profiler.adoc
@@ -1,0 +1,103 @@
+= Async-profiler
+
+Since https://issues.apache.org/jira/browse/CASSANDRA-20854[CASSANDRA-20854], it is possible to use
+https://github.com/async-profiler/async-profiler[async-profiler] to profile your nodes. Async-profiler is
+shipped with Cassandra, so you do not need to do anything else but start to use it by enabling a property.
+Async-profiler functionality is disabled by default. It can be turned on by setting Cassandra's `cassandra.async_profiler.enabled` property to `true`.
+
+There is a command in `nodetool` called `profile` with these sub-commands:
+
+== start
+
+Basic usage:
+----
+$ nodetool profile start
+----
+
+This will start profiling, by default for 60 seconds. If you want, for example, profile memory allocations for
+5 minutes and save results into a file memory-allocation-5m.html you would do:
+
+----
+$ nodetool profile start -e alloc -d 5m -o memory-allocation-5m.html
+----
+
+There are these events possible to profile:
+
+'cpu', 'alloc', 'lock', 'wall', 'nativemem', 'cache_misses', delimited by comma, defaults to 'cpu'.
+
+There are these output formats possible to specify, via `--format` flag:
+
+'flat', 'traces', 'collapsed', 'flamegraph', 'tree', 'jfr', 'otlp', defaults to 'flamegraph'
+
+== status
+
+You can then inspect the state of profiling by `status` subcommand:
+
+----
+$ nodetool profile status
+Profiling is running for 7 seconds
+----
+
+If you attempt to start another profiling while the current profiling is running, this will not be possible:
+
+----
+$ nodetool profile start -e alloc -d 5m -o memory-allocation-5m.html
+Profiler has already started or there was a failure to start it.
+----
+
+== stop
+
+You can stop the profiling prematurely by `stop` sub-command
+
+----
+$ nodetool profile stop -o memory-allocation-5m.html
+----
+
+After the profiling is finished, either by waiting until it stops on its own or by us explicitly, we have a result file in a results directory on a node. We can inspect what results there are by `list` sub-command:
+
+== list
+
+----
+$ nodetool profile list
+memory-allocation-5m.html
+cpu.html
+----
+
+== fetch
+
+If you have access to a node, you can just go to, by default,
+`logs` directory of Cassandra, into `async-profiler` and obtain a respective file. However, in a scenario when
+you are executing remote profiling (nodetool exection is on a physically different machine from Cassandra node), or you do not have the direct access to remote disk, you need to use `fetch` subcommand, which will sent the content of your result file locally where you can save it to whatever destination you want:
+
+----
+$ nodetool profile fetch cpu.html /tmp/cpu.html
+----
+
+== purge
+
+Of course, more you profile, more disk space the results will occupy. If you have direct access, you can just
+remove the files yourself, however if you do not, you need to use `purge` sub-command which will remove all profiling files:
+
+----
+$ nodetool profile purge
+$ nodetool profile list
+<no output>
+----
+
+== execute
+
+You can also execute arbitrary commands, by `execute` subcommand, like this:
+
+----
+nodetool profile execute meminfo
+Call trace storage:   10244 KB
+  Flight recording:       0 KB
+      Dictionaries:      68 KB
+        Code cache:   11934 KB
+------------------------------
+             Total:   22246 KB
+----
+
+However, to execute arbitrary commands for Async-profiler, we need to enable _unsafe_ async profiling by system property of Cassandra `cassandra.async_profiler.unsafe_mode` set to `true`. You will not be able to do this otherwise.
+
+You can also control where profiling files go via `cassandra.logdir.async_profiler` system property. When not set, by default they will be stored to `cassandra.logdir` + `async-profiler` directory.

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -60,7 +60,7 @@ public enum CassandraRelevantProperties
     ALLOW_UNSAFE_REPLACE("cassandra.allow_unsafe_replace"),
     ALLOW_UNSAFE_TRANSIENT_CHANGES("cassandra.allow_unsafe_transient_changes"),
     APPROXIMATE_TIME_PRECISION_MS("cassandra.approximate_time_precision_ms", "2"),
-    ASYNC_PROFILER_ENABLED("cassandra.async_profiler.enabled", "true"),
+    ASYNC_PROFILER_ENABLED("cassandra.async_profiler.enabled", "false"),
     ASYNC_PROFILER_LOG_DIR("cassandra.logdir.async_profiler"),
     ASYNC_PROFILER_UNSAFE_MODE("cassandra.async_profiler.unsafe_mode", "false"),
     /** 2 ** GENSALT_LOG2_ROUNDS rounds of hashing will be performed. */

--- a/src/java/org/apache/cassandra/profiler/AsyncProfiler.java
+++ b/src/java/org/apache/cassandra/profiler/AsyncProfiler.java
@@ -19,18 +19,57 @@
 package org.apache.cassandra.profiler;
 
 import java.util.List;
+import javax.management.StandardMBean;
 
-import org.apache.cassandra.tools.profiler.AsyncProfilerService;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.service.AsyncProfilerService;
+import org.apache.cassandra.utils.MBeanWrapper;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.ASYNC_PROFILER_UNSAFE_MODE;
 
 public abstract class AsyncProfiler implements AsyncProfilerMBean
 {
-    public static final String MBEAN_NAME = "org.apache.cassandra.profiler:type=AsyncProfiler";
     protected final AsyncProfilerService service = new AsyncProfilerService();
 
-    @Override
-    public boolean start(String events, String outputFormat, int timeout, String outputFileName)
+    private static AsyncProfiler instance;
+
+    public static synchronized AsyncProfiler instance()
     {
-        return service.start(events, outputFormat, timeout, outputFileName);
+        if (AsyncProfiler.instance == null)
+        {
+            try
+            {
+                AsyncProfiler.instance = ASYNC_PROFILER_UNSAFE_MODE.getBoolean() ? new AsyncProfilerUnsafe() : new AsyncProfilerSafe();
+
+                // register mbean first, before initialisation, which might fail (e.g. profiler functionality is disabled)
+                MBeanWrapper.instance.registerMBean(new StandardMBean(AsyncProfiler.instance, AsyncProfilerMBean.class),
+                                                    AsyncProfiler.MBEAN_NAME,
+                                                    MBeanWrapper.OnException.LOG);
+
+                instance.initialize();
+            }
+            catch (ConfigurationException ex)
+            {
+                throw ex;
+            }
+            catch (IllegalStateException ex)
+            {
+                if (!"Async-Profiler is not enabled.".equals(ex.getMessage()))
+                    throw ex;
+            }
+            catch (Throwable t)
+            {
+                throw new RuntimeException(t);
+            }
+        }
+
+        return AsyncProfiler.instance;
+    }
+
+    @Override
+    public boolean start(String events, String outputFormat, String duration, String outputFileName)
+    {
+        return service.start(events, outputFormat, duration, outputFileName);
     }
 
     @Override
@@ -70,9 +109,15 @@ public abstract class AsyncProfiler implements AsyncProfilerMBean
     }
 
     @Override
-    public String fetch(String resultFile)
+    public byte[] fetch(String resultFile)
     {
         return service.fetch(resultFile);
+    }
+
+    @Override
+    public String status()
+    {
+        return service.status();
     }
 
     public void initialize()

--- a/src/java/org/apache/cassandra/profiler/AsyncProfilerMBean.java
+++ b/src/java/org/apache/cassandra/profiler/AsyncProfilerMBean.java
@@ -20,22 +20,25 @@ package org.apache.cassandra.profiler;
 
 import java.util.List;
 
-import org.apache.cassandra.tools.profiler.AsyncProfilerService.AsyncProfilerEvent;
-import org.apache.cassandra.tools.profiler.AsyncProfilerService.AsyncProfilerFormat;
+import org.apache.cassandra.service.AsyncProfilerService.AsyncProfilerEvent;
+import org.apache.cassandra.service.AsyncProfilerService.AsyncProfilerFormat;
 
 public interface AsyncProfilerMBean
 {
+    String MBEAN_NAME = "org.apache.cassandra.profiler:type=AsyncProfiler";
+
     /**
      * Starts profiling.
      *
      * @param events         events, can be joined by a comma, each event has to be one of enum names of
      *                       {@link AsyncProfilerEvent}
      * @param outputFormat   output format, has to be one of enum names of {@link AsyncProfilerFormat}
-     * @param timeout        timeout, has to be strictly positive
+     * @param duration       duration of the profiling, Accepts string values in the
+     *                       form of {@code '5m'}, {@code '30s'} etc.
      * @param outputFileName file name to save results to
      * @return true if profiling has started, false when not (e.g. when it was started already)
      */
-    boolean start(String events, String outputFormat, int timeout, String outputFileName);
+    boolean start(String events, String outputFormat, String duration, String outputFileName);
 
     /**
      * Stops profiling.
@@ -86,7 +89,12 @@ public interface AsyncProfilerMBean
      * Returns the content of a result file. Use {@link #list()} to get their names.
      *
      * @param resultFile file with profiler results
-     * @return content of profiler resuls file, as string, null when not found
+     * @return content of profiler resuls file, or null, when not found.
      */
-    String fetch(String resultFile);
+    byte[] fetch(String resultFile);
+
+    /**
+     * @return status the profiler is in, as string description, for diagnostic purposes
+     */
+    String status();
 }

--- a/src/java/org/apache/cassandra/profiler/AsyncProfilerSafe.java
+++ b/src/java/org/apache/cassandra/profiler/AsyncProfilerSafe.java
@@ -18,6 +18,8 @@
 
 package org.apache.cassandra.profiler;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
+
 /**
  * Safe version is unable to execute any command.
  */
@@ -26,8 +28,12 @@ public class AsyncProfilerSafe extends AsyncProfiler
     @Override
     public String execute(String command)
     {
-        throw new SecurityException(String.format("Execute commands are not permitted " +
-                                                  "with this MBean. Please use unsafe MBean" +
-                                                  "if they are needed. Command: %s", command));
+        throw new SecurityException(String.format("The arbitrary command execution is not permitted " +
+                                                  "with %s MBean backed by %s class. If unsafe command execution is required, " +
+                                                  "start Cassandra with %s property set to true. " +
+                                                  "Rejected command: %s%n",
+                                                  AsyncProfiler.MBEAN_NAME,
+                                                  AsyncProfilerSafe.class.getName(),
+                                                  CassandraRelevantProperties.ASYNC_PROFILER_UNSAFE_MODE.name(), command));
     }
 }

--- a/src/java/org/apache/cassandra/service/AsyncProfilerService.java
+++ b/src/java/org/apache/cassandra/service/AsyncProfilerService.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.tools.profiler;
+package org.apache.cassandra.service;
 
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -31,9 +31,9 @@ import org.slf4j.LoggerFactory;
 import one.profiler.AsyncProfiler;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.config.DurationSpec;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.util.File;
-import org.apache.cassandra.service.StorageService;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
@@ -127,6 +127,9 @@ public class AsyncProfilerService
         if (!isEnabled())
             return;
 
+        if (isRunning())
+            stop(null);
+
         ASYNC_PROFILER_ENABLED.setBoolean(false);
         profilerInstance = null;
     }
@@ -158,7 +161,7 @@ public class AsyncProfilerService
         return profilerInstance;
     }
 
-    public synchronized boolean start(String events, String outputFormat, int timeout, String outputFileName)
+    public synchronized boolean start(String events, String outputFormat, String duration, String outputFileName)
     {
         if (isRunning())
             return false;
@@ -168,7 +171,7 @@ public class AsyncProfilerService
             String cmd = format("start,%s,event=%s,timeout=%s,file=%s",
                                 AsyncProfilerFormat.parseFormat(outputFormat),
                                 AsyncProfilerEvent.parseEvents(events),
-                                validateTimeout(timeout),
+                                parseDuration(duration),
                                 new File(logDir, validateOutputFileName(outputFileName)));
 
             String result = maybeInitialize().execute(cmd);
@@ -193,8 +196,13 @@ public class AsyncProfilerService
 
         try
         {
-            File outputFile = new File(logDir, validateOutputFileName(outputFileName));
-            String cmd = "stop,file=" + outputFile.absolutePath();
+            String cmd = "stop";
+            if (outputFileName != null)
+            {
+                File outputFile = new File(logDir, validateOutputFileName(outputFileName));
+                cmd += ",file=" + outputFile.absolutePath();
+            }
+
             String result = maybeInitialize().execute(cmd);
             logger.debug("Stopped Async-Profiler: result={}, cmd={}", result, cmd);
             return true;
@@ -229,6 +237,7 @@ public class AsyncProfilerService
     {
         try
         {
+            createLogDir();
             return Arrays.stream(new File(logDir).list()).map(File::name).sorted().collect(toList());
         }
         catch (Throwable t)
@@ -237,11 +246,12 @@ public class AsyncProfilerService
         }
     }
 
-    public String fetch(String resultFile)
+    public byte[] fetch(String resultFile)
     {
         try
         {
-            return Files.readString(new File(logDir, resultFile).toPath());
+            createLogDir();
+            return Files.readAllBytes(new File(logDir, resultFile).toPath());
         }
         catch (Throwable t)
         {
@@ -251,7 +261,20 @@ public class AsyncProfilerService
 
     public void purge()
     {
+        createLogDir();
         new File(logDir).deleteRecursive();
+    }
+
+    public String status()
+    {
+        try
+        {
+            return maybeInitialize().execute("status");
+        }
+        catch (Throwable t)
+        {
+            return t.getMessage();
+        }
     }
 
     public boolean isEnabled()
@@ -278,12 +301,13 @@ public class AsyncProfilerService
         return command;
     }
 
-    public static int validateTimeout(int timeout)
+    /**
+     * @param duration duration of profiling
+     * @return converted string representation of duration to seconds
+     */
+    public static int parseDuration(String duration)
     {
-        if (timeout <= 0)
-            throw new IllegalArgumentException("Timeout can not be negative or zero.");
-
-        return timeout;
+        return new DurationSpec.IntSecondsBound(duration).toSeconds();
     }
 
     /**

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -34,14 +34,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-import javax.management.NotCompliantMBeanException;
 import javax.management.StandardMBean;
 import javax.management.remote.JMXConnectorServer;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import org.apache.cassandra.profiler.AsyncProfiler;
-import org.apache.cassandra.profiler.AsyncProfilerMBean;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,8 +76,6 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.Locator;
-import org.apache.cassandra.profiler.AsyncProfilerSafe;
-import org.apache.cassandra.profiler.AsyncProfilerUnsafe;
 import org.apache.cassandra.tcm.CMSOperations;
 import org.apache.cassandra.tcm.ClusterMetadataService;
 import org.apache.cassandra.tcm.RegistrationStatus;
@@ -109,8 +106,6 @@ import org.apache.cassandra.utils.logging.SlowQueriesAppender;
 import org.apache.cassandra.utils.logging.VirtualTableAppender;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static org.apache.cassandra.config.CassandraRelevantProperties.ASYNC_PROFILER_UNSAFE_MODE;
-import static org.apache.cassandra.config.CassandraRelevantProperties.ASYNC_PROFILER_ENABLED;
 import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_FOREGROUND;
 import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_PID_FILE;
 import static org.apache.cassandra.config.CassandraRelevantProperties.COM_SUN_MANAGEMENT_JMXREMOTE_PORT;
@@ -264,6 +259,8 @@ public class CassandraDaemon
         logSystemInfo(logger);
 
         NativeLibrary.tryMlockall();
+
+        AsyncProfiler.instance();
 
         Keyspace.setInitialized();
         CommitLog.instance.start();
@@ -758,7 +755,6 @@ public class CassandraDaemon
             applyConfig();
 
             registerNativeAccess();
-            registerAsyncProfiler();
 
             setup();
 
@@ -809,31 +805,6 @@ public class CassandraDaemon
     public static void registerNativeAccess() throws javax.management.NotCompliantMBeanException
     {
         MBeanWrapper.instance.registerMBean(new StandardMBean(new NativeAccess(), NativeAccessMBean.class), MBEAN_NAME, MBeanWrapper.OnException.LOG);
-    }
-
-    @VisibleForTesting
-    public static void registerAsyncProfiler() throws javax.management.NotCompliantMBeanException
-    {
-        if (ASYNC_PROFILER_ENABLED.getBoolean())
-        {
-            try
-            {
-                AsyncProfiler asyncProfiler = ASYNC_PROFILER_UNSAFE_MODE.getBoolean() ? new AsyncProfilerUnsafe() : new AsyncProfilerSafe();
-                asyncProfiler.initialize();
-                
-                MBeanWrapper.instance.registerMBean(new StandardMBean(asyncProfiler, AsyncProfilerMBean.class),
-                                                    AsyncProfiler.MBEAN_NAME,
-                                                    MBeanWrapper.OnException.LOG);
-            }
-            catch (ConfigurationException | NotCompliantMBeanException t)
-            {
-                throw t;
-            }
-            catch (Throwable t)
-            {
-                logger.error("Error while registering Async-Profiler", t);
-            }
-        }
     }
 
     public void applyConfig()

--- a/src/java/org/apache/cassandra/service/StartupChecks.java
+++ b/src/java/org/apache/cassandra/service/StartupChecks.java
@@ -145,6 +145,7 @@ public class StartupChecks
                                                                       checkSSTablesFormat,
                                                                       checkSystemKeyspaceState,
                                                                       checkLegacyAuthTables,
+                                                                      checkKernelParamsForAsyncProfiler,
                                                                       new DataResurrectionCheck());
 
     public StartupChecks withDefaultTests()
@@ -746,6 +747,46 @@ public class StartupChecks
             Optional<String> errMsg = checkLegacyAuthTablesMessage();
             if (errMsg.isPresent())
                 throw new StartupException(StartupException.ERR_WRONG_CONFIG, errMsg.get());
+        }
+    };
+
+    public static final StartupCheck checkKernelParamsForAsyncProfiler = new StartupCheck()
+    {
+        @Override
+        public void execute(StartupChecksOptions startupChecksOptions)
+        {
+            try
+            {
+                if (!CassandraRelevantProperties.ASYNC_PROFILER_ENABLED.getBoolean())
+                    return;
+
+                List<String> perfEventParanoidLines = FileUtils.readLines(new File("/proc/sys/kernel/perf_event_paranoid"));
+                int perfEventParanoid = Integer.MIN_VALUE;
+                if (!perfEventParanoidLines.isEmpty())
+                    perfEventParanoid = Integer.parseInt(perfEventParanoidLines.get(0));
+
+                List<String> kptrRestrictLines = FileUtils.readLines(new File("/proc/sys/kernel/kptr_restrict"));
+                int kptrRestrict = Integer.MIN_VALUE;
+                if (!kptrRestrictLines.isEmpty())
+                    kptrRestrict = Integer.parseInt(kptrRestrictLines.get(0));
+
+                if (perfEventParanoid == Integer.MIN_VALUE || kptrRestrict == Integer.MIN_VALUE)
+                {
+                    logger.debug("Unable to determine values for kernel parameter of " +
+                                 "'kernel.perf_event_paranoid' and 'kernel.kptr_restrict' for Async-profiler. " +
+                                 "Its usability might be limited.");
+                }
+                else if (perfEventParanoid != 1 || kptrRestrict != 0)
+                {
+                        logger.warn("Async-profiler experience likely affected. Kernel symbols are unavailable due to restrictions. " +
+                                    "Try 'sysctl kernel.perf_event_paranoid=1' and 'sysctl kernel.kptr_restrict=0' or its " +
+                                    "variation on your system to resolve the issue.");
+                }
+            }
+            catch (Throwable t)
+            {
+                // ignore, these are reported on best-effort basis
+            }
         }
     };
 

--- a/src/java/org/apache/cassandra/tools/nodetool/AsyncProfileCommandGroup.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/AsyncProfileCommandGroup.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.tools.nodetool;
 
+import java.nio.file.Files;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -27,8 +28,8 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.profiler.AsyncProfilerMBean;
 import org.apache.cassandra.tools.NodeProbe;
-import org.apache.cassandra.tools.profiler.AsyncProfilerService.AsyncProfilerEvent;
-import org.apache.cassandra.tools.profiler.AsyncProfilerService.AsyncProfilerFormat;
+import org.apache.cassandra.service.AsyncProfilerService.AsyncProfilerEvent;
+import org.apache.cassandra.service.AsyncProfilerService.AsyncProfilerFormat;
 import org.apache.cassandra.utils.FBUtilities;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -38,18 +39,19 @@ import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.nio.file.StandardOpenOption.WRITE;
 import static java.util.stream.Collectors.joining;
-import static org.apache.cassandra.tools.profiler.AsyncProfilerService.validateCommand;
-import static org.apache.cassandra.tools.profiler.AsyncProfilerService.validateOutputFileName;
-import static org.apache.cassandra.tools.profiler.AsyncProfilerService.validateTimeout;
+import static org.apache.cassandra.service.AsyncProfilerService.parseDuration;
+import static org.apache.cassandra.service.AsyncProfilerService.validateCommand;
+import static org.apache.cassandra.service.AsyncProfilerService.validateOutputFileName;
 
 @Command(name = "profile", description = "Manage Async-Profiler on a Cassandra process",
 subcommands = {
 AsyncProfileCommandGroup.AsyncProfileStartCommand.class,
 AsyncProfileCommandGroup.AsyncProfileStopCommand.class,
-AsyncProfileCommandGroup.AsyncProfileRawCommand.class,
+AsyncProfileCommandGroup.AsyncProfileExecuteCommand.class,
 AsyncProfileCommandGroup.AsyncProfilePurgeCommand.class,
 AsyncProfileCommandGroup.AsyncProfileListCommand.class,
-AsyncProfileCommandGroup.AsyncProfileFetchCommand.class
+AsyncProfileCommandGroup.AsyncProfileFetchCommand.class,
+AsyncProfileCommandGroup.AsyncProfileStatusCommand.class
 })
 public class AsyncProfileCommandGroup extends AbstractCommand
 {
@@ -62,17 +64,22 @@ public class AsyncProfileCommandGroup extends AbstractCommand
         cmd.run();
     }
 
-    public static void doWithProfiler(NodeProbe probe, Consumer<AsyncProfilerMBean> consumer)
+    public static void doWithProfiler(NodeProbe probe, Consumer<AsyncProfilerMBean> consumer, boolean requiresEnabledProfiler)
     {
         AsyncProfilerMBean profiler = probe.getAsyncProfilerProxy();
 
-        if (!profiler.isEnabled())
+        if (requiresEnabledProfiler && !profiler.isEnabled())
         {
-            probe.output().err.println("Async-profiler native library is not loaded or unavailable.");
+            probe.output().err.println("Async-profiler native library is not enabled or not possible to load.");
             System.exit(1);
         }
 
         consumer.accept(profiler);
+    }
+
+    public static void doWithProfiler(NodeProbe probe, Consumer<AsyncProfilerMBean> consumer)
+    {
+        doWithProfiler(probe, consumer, true);
     }
 
     @Command(name = "start", description = "Run Async-Profiler on a Cassandra process")
@@ -80,27 +87,32 @@ public class AsyncProfileCommandGroup extends AbstractCommand
     {
         @Option(names = { "-e", "--event" },
         description = "Event(s) to profile, one of or combination of 'cpu', 'alloc', " +
-                      "'lock', 'wall', 'nativemem', 'cache_misses', delimited by comma.")
+                      "'lock', 'wall', 'nativemem', 'cache_misses', delimited by comma, defaults to 'cpu'")
         public List<AsyncProfilerEvent> event = List.of(AsyncProfilerEvent.cpu);
 
-        @Option(names = { "-o", "--output" }, description = "File Name")
+        @Option(names = { "-o", "--output" }, description = "File name to save profiling results into, defaults to a " +
+                                                            "file of name 'yyyy-MM-dd-HH-mm-ss.html'")
         public String filename = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss")
                                                   .withZone(ZoneId.systemDefault()).format(FBUtilities.now()) + ".html";
 
-        @Option(names = { "-t", "--timeout" }, description = "Timeout in seconds")
-        public int timeout = 60;
+        @Option(names = { "-d", "--duration" }, description = "Duration of profiling, defaults to '60s'. Accepts string values " +
+                                                              "in the form of '5m', '30s' and similar.")
+        public String duration = "60s";
 
         @Option(names = { "-f", "--format" },
-        description = "Output format, one of 'flat', 'traces', 'collapsed', 'flamegraph', 'tree', 'jfr', 'otlp'")
+        description = "Output format, one of 'flat', 'traces', 'collapsed', 'flamegraph', 'tree', 'jfr', 'otlp', defaults to 'flamegraph'")
         public AsyncProfilerFormat outputFormat = AsyncProfilerFormat.flamegraph;
 
         @Override
         public void execute(NodeProbe probe)
         {
+            // make sure it is valid
+            parseDuration(duration);
+
             doWithProfiler(probe, profiler -> {
                 if (!profiler.start(event.stream().map(Enum::name).collect(joining(",")),
                                     outputFormat.name(),
-                                    validateTimeout(timeout),
+                                    duration,
                                     validateOutputFileName(filename)))
                 {
                     output.err.println("Profiler has already started or there was a failure to start it.");
@@ -113,7 +125,8 @@ public class AsyncProfileCommandGroup extends AbstractCommand
     @Command(name = "stop", description = "Stop Async-Profiler on a Cassandra process")
     public static class AsyncProfileStopCommand extends AbstractCommand
     {
-        @Option(names = { "-o", "--output" }, description = "File Name")
+        @Option(names = { "-o", "--output" }, description = "File name to save profiling results into, defaults to a " +
+                                                            "file of name 'yyyy-MM-dd-HH-mm-ss.html'")
         public String filename = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss")
                                                   .withZone(ZoneId.systemDefault()).format(FBUtilities.now()) + ".html";
 
@@ -130,17 +143,27 @@ public class AsyncProfileCommandGroup extends AbstractCommand
         }
     }
 
-    @Command(name = "raw", description = "Execute an arbitrary command on Async-Profiler on a Cassandra process")
-    public static class AsyncProfileRawCommand extends AbstractCommand
+    @Command(name = "execute", description = "Execute an arbitrary command on Async-Profiler on a Cassandra process.")
+    public static class AsyncProfileExecuteCommand extends AbstractCommand
     {
-        @Option(names = { "-c", "--command" }, description = "Raw commands to execute")
+        @Parameters(index = "0", description = "Raw command to execute. There has to be 'unsafe' profiler configured " +
+                                               "in Cassandra, driven by cassandra.async_profiler.unsafe_mode property set" +
+                                               " to true, to be able to do this.", arity = "1")
         public String command;
 
         @Override
         public void execute(NodeProbe probe)
         {
             doWithProfiler(probe, profiler -> {
-                output.out.println(profiler.execute(validateCommand(command)));
+                try
+                {
+                    output.out.print(profiler.execute(validateCommand(command)));
+                }
+                catch (SecurityException ex)
+                {
+                    output.err.print(ex.getMessage());
+                    System.exit(1);
+                }
             });
         }
     }
@@ -151,7 +174,7 @@ public class AsyncProfileCommandGroup extends AbstractCommand
         @Override
         protected void execute(NodeProbe probe)
         {
-            doWithProfiler(probe, AsyncProfilerMBean::purge);
+            doWithProfiler(probe, AsyncProfilerMBean::purge, false);
         }
     }
 
@@ -164,13 +187,16 @@ public class AsyncProfileCommandGroup extends AbstractCommand
             doWithProfiler(probe, profiler -> {
                 for (String resultFile : profiler.list())
                     output.out.println(resultFile);
-            });
+            }, false);
         }
     }
 
-    @Command(name = "fetch", description = "Copy profiler result file from node to a local file")
+    @Command(name = "fetch", description = "Copy profiler result file from a node to a local file")
     public static class AsyncProfileFetchCommand extends AbstractCommand
     {
+        @Option(names = { "-b", "--binary" }, description = "treat file to be downloaded having binary content, not string one.")
+        private boolean binary;
+
         @Parameters(index = "0", description = "Remote profiler file name", arity = "1")
         private String remoteFile;
 
@@ -181,15 +207,58 @@ public class AsyncProfileCommandGroup extends AbstractCommand
         protected void execute(NodeProbe probe)
         {
             doWithProfiler(probe, profiler -> {
-                String content = profiler.fetch(remoteFile);
-                if (content != null)
-                    FileUtils.write(new File(localFile), List.of(content), CREATE, TRUNCATE_EXISTING, WRITE);
+                if (binary)
+                {
+                    doWithContent(profiler, remoteFile, content -> {
+                        try
+                        {
+                            Files.write(new File(localFile).toPath(), content, CREATE, TRUNCATE_EXISTING, WRITE);
+                        }
+                        catch (Throwable t)
+                        {
+                            throw new RuntimeException(t);
+                        }
+                    });
+                }
                 else
                 {
-                    output.out.println("File " + remoteFile + " does not exist.");
+                    doWithContent(profiler,
+                                  remoteFile,
+                                  content -> FileUtils.write(new File(localFile),
+                                                             List.of(new String(content)),
+                                                             CREATE,
+                                                             TRUNCATE_EXISTING,
+                                                             WRITE));
+                }
+            }, false);
+        }
+
+        private void doWithContent(AsyncProfilerMBean profiler, String remoteFile, Consumer<byte[]> consumer)
+        {
+            try
+            {
+                byte[] content = profiler.fetch(remoteFile);
+                if (content == null)
+                {
+                    output.err.println("Remote file " + remoteFile + " not found or error occurred while returning it.");
                     System.exit(1);
                 }
-            });
+                consumer.accept(content);
+            }
+            catch (Throwable t)
+            {
+                System.exit(1);
+            }
+        }
+    }
+
+    @Command(name = "status", description = "Get status of profiling")
+    public static class AsyncProfileStatusCommand extends AbstractCommand
+    {
+        @Override
+        protected void execute(NodeProbe probe)
+        {
+            doWithProfiler(probe, profiler -> output.out.print(profiler.status()));
         }
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/mock/nodetool/InternalNodeProbe.java
+++ b/test/distributed/org/apache/cassandra/distributed/mock/nodetool/InternalNodeProbe.java
@@ -40,6 +40,7 @@ import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
 import org.apache.cassandra.locator.SnitchAdapter;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.profiler.AsyncProfiler;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.service.CacheService;
 import org.apache.cassandra.service.CacheServiceMBean;
@@ -90,6 +91,7 @@ public class InternalNodeProbe extends NodeProbe
         arsProxy = ActiveRepairService.instance();
         memProxy = ManagementFactory.getMemoryMXBean();
         runtimeProxy = ManagementFactory.getRuntimeMXBean();
+        asyncProfilerProxy = AsyncProfiler.instance();
     }
 
     @Override

--- a/test/distributed/org/apache/cassandra/distributed/test/AsyncProfilerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/AsyncProfilerTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.distributed.api.IIsolatedExecutor.SerializableCallable;
+import org.apache.cassandra.distributed.api.IIsolatedExecutor.SerializableRunnable;
+import org.apache.cassandra.distributed.api.NodeToolResult;
+import org.apache.cassandra.distributed.shared.Uninterruptibles;
+import org.apache.cassandra.distributed.shared.WithProperties;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.profiler.AsyncProfiler;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.cassandra.config.CassandraRelevantProperties.ASYNC_PROFILER_ENABLED;
+import static org.apache.cassandra.config.CassandraRelevantProperties.ASYNC_PROFILER_LOG_DIR;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AsyncProfilerTest extends TestBaseImpl
+{
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+
+    private Cluster cluster;
+
+    @Test
+    public void testNodetoolCommands() throws Throwable
+    {
+        File newTmpDir = new File(tmpDir.newFolder());
+
+        try (WithProperties withProperties = new WithProperties()
+                                             .set(ASYNC_PROFILER_ENABLED, true)
+                                             .set(ASYNC_PROFILER_LOG_DIR, newTmpDir.absolutePath());
+             Cluster cluster = init(builder().withNodes(1).withConfig(c -> c.with(Feature.JMX)).start()))
+        {
+            this.cluster = cluster;
+
+            // start / stop / list
+            assertTrue(status().contains("Profiler is not active"));
+            startAndAssert();
+            Uninterruptibles.sleepUninterruptibly(10, SECONDS);
+            stop();
+
+            // start / stop with file name
+            startAndAssert();
+            Uninterruptibles.sleepUninterruptibly(10, SECONDS);
+            String fileName = UUID.randomUUID().toString();
+            stop(fileName);
+            assertTrue(list().contains(fileName));
+
+            // fetch
+            File destination = new File(newTmpDir, UUID.randomUUID().toString());
+            fetch(fileName, destination.absolutePath());
+            assertTrue(destination.length() != 0);
+
+            // list
+            assertFalse(list().isEmpty());
+            assertTrue(list().contains(fileName));
+
+            // purge
+            purge();
+            assertTrue(list().isEmpty());
+
+            // double start
+            startAndAssert();
+            NodeToolResult secondStart = start();
+            secondStart.asserts().failure();
+            assertTrue(secondStart.getStderr().contains("Profiler has already started"));
+
+            // disable while it is running
+            cluster.get(1).runOnInstance((SerializableRunnable) () -> AsyncProfiler.instance().disable());
+            NodeToolResult statusResult = cluster.get(1).nodetoolResult("profile", "status");
+            statusResult.asserts().failure();
+            assertTrue(statusResult.getStderr().contains("Async-profiler native library is not enabled or not possible to load."));
+            assertFalse(cluster.get(1).callOnInstance((SerializableCallable<Boolean>) () -> AsyncProfiler.instance().isEnabled()));
+
+            // we can enable it back again
+            cluster.get(1).runOnInstance((SerializableRunnable) () -> AsyncProfiler.instance().enable());
+            startAndAssert();
+            Uninterruptibles.sleepUninterruptibly(5, SECONDS);
+            stop();
+            statusResult = cluster.get(1).nodetoolResult("profile", "status");
+            String stdout = statusResult.getStdout();
+            assertTrue(statusResult.getStdout().contains("Profiler is not active"));
+        }
+    }
+
+    @Test
+    public void testListPurgeFetchWorksWithDisabledProfiler() throws Throwable
+    {
+        File newTmpDir = new File(tmpDir.newFolder());
+        try (WithProperties withProperties = new WithProperties().set(ASYNC_PROFILER_ENABLED, false)
+                                                                 .set(ASYNC_PROFILER_LOG_DIR, newTmpDir.absolutePath());
+             Cluster cluster = init(builder().withNodes(1).withConfig(c -> c.with(Feature.JMX)).start()))
+        {
+            this.cluster = cluster;
+
+            String fileNameToWriteTo = UUID.randomUUID().toString();
+
+            FileUtils.write(new File(newTmpDir, fileNameToWriteTo), List.of("hello world"), StandardOpenOption.CREATE_NEW);
+
+            // fetch
+            String destinationFileName = UUID.randomUUID().toString();
+            File destination = new File(newTmpDir, destinationFileName);
+            fetch(fileNameToWriteTo, destination.absolutePath());
+            assertTrue(destination.length() != 0);
+
+            // list
+            assertFalse(list().isEmpty());
+            assertTrue(list().contains(fileNameToWriteTo));
+
+            // purge
+            purge();
+            assertTrue(list().isEmpty());
+        }
+    }
+
+    private String list()
+    {
+        NodeToolResult result = cluster.get(1).nodetoolResult("profile", "list");
+        result.asserts().success();
+        return result.getStdout();
+    }
+
+    private void stop()
+    {
+        NodeToolResult result = cluster.get(1).nodetoolResult("profile", "stop");
+        result.asserts().success();
+    }
+
+    private void stop(String file)
+    {
+        NodeToolResult result = cluster.get(1).nodetoolResult("profile", "stop", "-o", file);
+        result.asserts().success();
+    }
+
+    private NodeToolResult startAndAssert()
+    {
+        NodeToolResult result = cluster.get(1).nodetoolResult("profile", "start", "-e", "cpu");
+        result.asserts().success();
+        return result;
+    }
+
+    private NodeToolResult start()
+    {
+        return cluster.get(1).nodetoolResult("profile", "start", "-e", "cpu");
+    }
+
+    private String status()
+    {
+        NodeToolResult result = cluster.get(1).nodetoolResult("profile", "status");
+        result.asserts().success();
+        return result.getStdout();
+    }
+
+    private void purge()
+    {
+        NodeToolResult result = cluster.get(1).nodetoolResult("profile", "purge");
+        result.asserts().success();
+    }
+
+    private void fetch(String what, String where)
+    {
+        NodeToolResult result = cluster.get(1).nodetoolResult("profile", "fetch", what, where);
+        result.asserts().success();
+    }
+}

--- a/test/resources/nodetool/help/profile
+++ b/test/resources/nodetool/help/profile
@@ -11,10 +11,10 @@ SYNOPSIS
                 [(-pp | --print-port)] [(-pw <password> | --password <password>)]
                 [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
                 [(-u <username> | --username <username>)] profile start
+                [(-d <duration> | --duration <duration>)]
                 [(-e <event> | --event <event>)...]
                 [(-f <outputFormat> | --format <outputFormat>)]
                 [(-o <filename> | --output <filename>)]
-                [(-t <timeout> | --timeout <timeout>)]
 
         nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
                 [(-pp | --print-port)] [(-pw <password> | --password <password>)]
@@ -25,8 +25,28 @@ SYNOPSIS
         nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
                 [(-pp | --print-port)] [(-pw <password> | --password <password>)]
                 [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
-                [(-u <username> | --username <username>)] profile raw
-                [(-c <command> | --command <command>)]
+                [(-u <username> | --username <username>)] profile execute [--] <command>
+
+        nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
+                [(-pp | --print-port)] [(-pw <password> | --password <password>)]
+                [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
+                [(-u <username> | --username <username>)] profile purge
+
+        nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
+                [(-pp | --print-port)] [(-pw <password> | --password <password>)]
+                [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
+                [(-u <username> | --username <username>)] profile list
+
+        nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
+                [(-pp | --print-port)] [(-pw <password> | --password <password>)]
+                [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
+                [(-u <username> | --username <username>)] profile fetch
+                [(-b | --binary)] [--] <remoteFile> <localFile>
+
+        nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
+                [(-pp | --print-port)] [(-pw <password> | --password <password>)]
+                [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
+                [(-u <username> | --username <username>)] profile status
 
 OPTIONS
         -h <host>, --host <host>
@@ -54,19 +74,32 @@ COMMANDS
             Run Async-Profiler on a Cassandra process
 
             With --event option, Event(s) to profile, one of or combination of 'cpu',
-            'alloc', 'lock', 'wall', 'nativemem', 'cache_misses', delimited by comma.
+            'alloc', 'lock', 'wall', 'nativemem', 'cache_misses', delimited by comma,
+            defaults to 'cpu'
 
-            With --output option, File Name
+            With --output option, File name to save profiling results into, defaults to
+            a file of name 'yyyy-MM-dd-HH-mm-ss.html'
 
-            With --timeout option, Timeout in seconds
+            With --duration option, Duration of profiling, defaults to '60s'. Accepts
+            string values in the form of '5m', '30s' and similar.
 
             With --format option, Output format, one of 'flat', 'traces', 'collapsed',
-            'flamegraph', 'tree', 'jfr', 'otlp'
+            'flamegraph', 'tree', 'jfr', 'otlp', defaults to 'flamegraph'
         stop
             Stop Async-Profiler on a Cassandra process
 
-            With --output option, File Name
-        raw
-            Execute an arbitrary command on Async-Profiler on a Cassandra process
+            With --output option, File name to save profiling results into, defaults to
+            a file of name 'yyyy-MM-dd-HH-mm-ss.html'
+        execute
+            Execute an arbitrary command on Async-Profiler on a Cassandra process.
+        purge
+            Remove all profiling results from node's disk
+        list
+            List profiling result files of a node
+        fetch
+            Copy profiler result file from a node to a local file
 
-            With --command option, Raw commands to execute
+            With --binary option, treat file to be downloaded having binary content,
+            not string one.
+        status
+            Get status of profiling

--- a/test/resources/nodetool/help/profile$execute
+++ b/test/resources/nodetool/help/profile$execute
@@ -1,20 +1,16 @@
 NAME
-        nodetool profile stop - Stop Async-Profiler on a Cassandra process
+        nodetool profile execute - Execute an arbitrary command on
+        Async-Profiler on a Cassandra process.
 
 SYNOPSIS
         nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
                 [(-pp | --print-port)] [(-pw <password> | --password <password>)]
                 [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
-                [(-u <username> | --username <username>)] profile stop
-                [(-o <filename> | --output <filename>)]
+                [(-u <username> | --username <username>)] profile execute [--] <command>
 
 OPTIONS
         -h <host>, --host <host>
             Node hostname or ip address
-
-        -o <filename>, --output <filename>
-            File name to save profiling results into, defaults to a file of
-            name 'yyyy-MM-dd-HH-mm-ss.html'
 
         -p <port>, --port <port>
             Remote jmx agent port number
@@ -30,3 +26,13 @@ OPTIONS
 
         -u <username>, --username <username>
             Remote jmx agent username
+
+        --
+            This option can be used to separate command-line options from the
+            list of argument, (useful when arguments might be mistaken for
+            command-line options
+
+        <command>
+            Raw command to execute. There has to be 'unsafe' profiler
+            configured in Cassandra, driven by cassandra.async_profiler.
+            unsafe_mode property set to true, to be able to do this.

--- a/test/resources/nodetool/help/profile$fetch
+++ b/test/resources/nodetool/help/profile$fetch
@@ -1,20 +1,20 @@
 NAME
-        nodetool profile stop - Stop Async-Profiler on a Cassandra process
+        nodetool profile fetch - Copy profiler result file from a node to a
+        local file
 
 SYNOPSIS
         nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
                 [(-pp | --print-port)] [(-pw <password> | --password <password>)]
                 [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
-                [(-u <username> | --username <username>)] profile stop
-                [(-o <filename> | --output <filename>)]
+                [(-u <username> | --username <username>)] profile fetch
+                [(-b | --binary)] [--] <remoteFile> <localFile>
 
 OPTIONS
+        -b, --binary
+            treat file to be downloaded having binary content, not string one.
+
         -h <host>, --host <host>
             Node hostname or ip address
-
-        -o <filename>, --output <filename>
-            File name to save profiling results into, defaults to a file of
-            name 'yyyy-MM-dd-HH-mm-ss.html'
 
         -p <port>, --port <port>
             Remote jmx agent port number
@@ -30,3 +30,14 @@ OPTIONS
 
         -u <username>, --username <username>
             Remote jmx agent username
+
+        --
+            This option can be used to separate command-line options from the
+            list of argument, (useful when arguments might be mistaken for
+            command-line options
+
+        <remoteFile>
+            Remote profiler file name
+
+        <localFile>
+            Local file name

--- a/test/resources/nodetool/help/profile$list
+++ b/test/resources/nodetool/help/profile$list
@@ -1,20 +1,15 @@
 NAME
-        nodetool profile stop - Stop Async-Profiler on a Cassandra process
+        nodetool profile list - List profiling result files of a node
 
 SYNOPSIS
         nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
                 [(-pp | --print-port)] [(-pw <password> | --password <password>)]
                 [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
-                [(-u <username> | --username <username>)] profile stop
-                [(-o <filename> | --output <filename>)]
+                [(-u <username> | --username <username>)] profile list
 
 OPTIONS
         -h <host>, --host <host>
             Node hostname or ip address
-
-        -o <filename>, --output <filename>
-            File name to save profiling results into, defaults to a file of
-            name 'yyyy-MM-dd-HH-mm-ss.html'
 
         -p <port>, --port <port>
             Remote jmx agent port number

--- a/test/resources/nodetool/help/profile$purge
+++ b/test/resources/nodetool/help/profile$purge
@@ -1,20 +1,15 @@
 NAME
-        nodetool profile stop - Stop Async-Profiler on a Cassandra process
+        nodetool profile purge - Remove all profiling results from node's disk
 
 SYNOPSIS
         nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
                 [(-pp | --print-port)] [(-pw <password> | --password <password>)]
                 [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
-                [(-u <username> | --username <username>)] profile stop
-                [(-o <filename> | --output <filename>)]
+                [(-u <username> | --username <username>)] profile purge
 
 OPTIONS
         -h <host>, --host <host>
             Node hostname or ip address
-
-        -o <filename>, --output <filename>
-            File name to save profiling results into, defaults to a file of
-            name 'yyyy-MM-dd-HH-mm-ss.html'
 
         -p <port>, --port <port>
             Remote jmx agent port number

--- a/test/resources/nodetool/help/profile$start
+++ b/test/resources/nodetool/help/profile$start
@@ -6,25 +6,31 @@ SYNOPSIS
                 [(-pp | --print-port)] [(-pw <password> | --password <password>)]
                 [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
                 [(-u <username> | --username <username>)] profile start
+                [(-d <duration> | --duration <duration>)]
                 [(-e <event> | --event <event>)...]
                 [(-f <outputFormat> | --format <outputFormat>)]
                 [(-o <filename> | --output <filename>)]
-                [(-t <timeout> | --timeout <timeout>)]
 
 OPTIONS
+        -d <duration>, --duration <duration>
+            Duration of profiling, defaults to '60s'. Accepts string values in
+            the form of '5m', '30s' and similar.
+
         -e <event>, --event <event>
             Event(s) to profile, one of or combination of 'cpu', 'alloc',
-            'lock', 'wall', 'nativemem', 'cache_misses', delimited by comma.
+            'lock', 'wall', 'nativemem', 'cache_misses', delimited by comma,
+            defaults to 'cpu'
 
         -f <outputFormat>, --format <outputFormat>
             Output format, one of 'flat', 'traces', 'collapsed', 'flamegraph',
-            'tree', 'jfr', 'otlp'
+            'tree', 'jfr', 'otlp', defaults to 'flamegraph'
 
         -h <host>, --host <host>
             Node hostname or ip address
 
         -o <filename>, --output <filename>
-            File Name
+            File name to save profiling results into, defaults to a file of
+            name 'yyyy-MM-dd-HH-mm-ss.html'
 
         -p <port>, --port <port>
             Remote jmx agent port number
@@ -37,9 +43,6 @@ OPTIONS
 
         -pwf <passwordFilePath>, --password-file <passwordFilePath>
             Path to the JMX password file
-
-        -t <timeout>, --timeout <timeout>
-            Timeout in seconds
 
         -u <username>, --username <username>
             Remote jmx agent username

--- a/test/resources/nodetool/help/profile$status
+++ b/test/resources/nodetool/help/profile$status
@@ -1,18 +1,13 @@
 NAME
-        nodetool profile raw - Execute an arbitrary command on Async-Profiler
-        on a Cassandra process
+        nodetool profile status - Get status of profiling
 
 SYNOPSIS
         nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
                 [(-pp | --print-port)] [(-pw <password> | --password <password>)]
                 [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
-                [(-u <username> | --username <username>)] profile raw
-                [(-c <command> | --command <command>)]
+                [(-u <username> | --username <username>)] profile status
 
 OPTIONS
-        -c <command>, --command <command>
-            Raw commands to execute
-
         -h <host>, --host <host>
             Node hostname or ip address
 

--- a/test/unit/org/apache/cassandra/tools/AsyncProfilerServiceTest.java
+++ b/test/unit/org/apache/cassandra/tools/AsyncProfilerServiceTest.java
@@ -39,7 +39,10 @@ import static java.lang.String.format;
 import static org.apache.cassandra.config.CassandraRelevantProperties.ASYNC_PROFILER_ENABLED;
 import static org.apache.cassandra.config.CassandraRelevantProperties.ASYNC_PROFILER_LOG_DIR;
 import static org.apache.cassandra.config.CassandraRelevantProperties.ASYNC_PROFILER_UNSAFE_MODE;
+import static org.apache.cassandra.service.AsyncProfilerService.AsyncProfilerEvent.cpu;
+import static org.apache.cassandra.service.AsyncProfilerService.AsyncProfilerFormat.flamegraph;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -95,7 +98,7 @@ public class AsyncProfilerServiceTest
     public void testStartAndStopProfiling() throws Throwable
     {
         AsyncProfiler profiler = getProfiler();
-        profiler.start("cpu", "flamegraph", 10, testOutputFile.name());
+        profiler.start(cpu.name(), flamegraph.name(), "10s", testOutputFile.name());
         Thread.sleep(5000);
         profiler.stop(testOutputFile.name());
 
@@ -107,14 +110,16 @@ public class AsyncProfilerServiceTest
 
         Optional<String> resultFile = list.stream().filter(f -> f.equals(testOutputFile.name())).findFirst();
         assertTrue(resultFile.isPresent());
-        String fetch = profiler.fetch(resultFile.get());
-        assertNotNull(fetch);
+        byte[] content = profiler.fetch(resultFile.get());
+        assertNotNull(content);
+
+        assertEquals("Profiler is not active\n", profiler.status());
     }
 
     @Test
     public void testInvalidEventThrowsException()
     {
-        assertThatThrownBy(() -> getProfiler().start("not_a_real_event", "flamegraph", 60, testOutputFile.absolutePath()))
+        assertThatThrownBy(() -> getProfiler().start("not_a_real_event", "flamegraph", "60s", testOutputFile.absolutePath()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Event must be one or a combination of [cpu, alloc, lock, wall, nativemem, cache_misses]");
     }
@@ -122,7 +127,7 @@ public class AsyncProfilerServiceTest
     @Test
     public void testInvalidFormatThrowsException()
     {
-        assertThatThrownBy(() -> getProfiler().start("cpu", "not_a_real_format", 60, testOutputFile.absolutePath()))
+        assertThatThrownBy(() -> getProfiler().start(cpu.name(), "not_a_real_format", "60s", testOutputFile.absolutePath()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Format must be one of [flat, traces, collapsed, flamegraph, tree, jfr, otlp]");
     }
@@ -130,9 +135,9 @@ public class AsyncProfilerServiceTest
     @Test
     public void testInvalidOutputFileNameThrowsException()
     {
-        assertThatThrownBy(() -> getProfiler().start("cpu",
-                                                     "flamegraph",
-                                                     60,
+        assertThatThrownBy(() -> getProfiler().start(cpu.name(),
+                                                     flamegraph.name(),
+                                                     "60s",
                                                      "| grep test"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Output file name must match pattern ^[a-zA-Z0-9-]*\\.?[a-zA-Z0-9-]*$");
@@ -141,20 +146,22 @@ public class AsyncProfilerServiceTest
     @Test
     public void testInvalidTimeoutThrowsException()
     {
-        assertThatThrownBy(() -> getProfiler().start("cpu",
-                                                     "flamegraph",
-                                                     -10,
-                                                     "| grep test"))
+        assertThatThrownBy(() -> {
+            getProfiler().start(cpu.name(),
+                                flamegraph.name(),
+                                "10abc",
+                                "| grep test");
+        })
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Timeout can not be negative or zero.");
+        .hasMessageContaining("Invalid duration: 10abc Accepted units:[SECONDS, MINUTES, HOURS, DAYS] where case matters and only non-negative values.");
     }
 
     @Test
     public void testSecondStartNotExecuted()
     {
         AsyncProfiler profiler = getProfiler();
-        assertTrue(profiler.start("cpu", "flamegraph", 60, testOutputFile.name()));
-        assertFalse(profiler.start("cpu", "flamegraph", 60, testOutputFile.name()));
+        assertTrue(profiler.start(cpu.name(), flamegraph.name(), "60s", testOutputFile.name()));
+        assertFalse(profiler.start(cpu.name(), flamegraph.name(), "60s", testOutputFile.name()));
         profiler.stop(testOutputFile.name());
     }
 
@@ -164,7 +171,7 @@ public class AsyncProfilerServiceTest
         assertThatThrownBy(() -> {
             AsyncProfiler profiler = getProfiler();
             profiler.disable();
-            profiler.execute("start,event=cpu,file=" + testOutputFile.absolutePath());
+            profiler.execute("start,event=" + cpu.name() + ",file=" + testOutputFile.absolutePath());
         }).hasCauseExactlyInstanceOf(IllegalStateException.class)
           .hasMessageContaining("Async-Profiler is not enabled.");
     }
@@ -175,7 +182,7 @@ public class AsyncProfilerServiceTest
         ASYNC_PROFILER_UNSAFE_MODE.setBoolean(true);
         AsyncProfiler profiler = getProfiler();
 
-        profiler.execute("start,event=cpu,file=" + testOutputFile.absolutePath());
+        profiler.execute("start,event=" + cpu.name() + ",file=" + testOutputFile.absolutePath());
         Thread.sleep(5000);
         profiler.execute(format("stop,file=%s", testOutputFile));
 
@@ -199,9 +206,10 @@ public class AsyncProfilerServiceTest
         {
             assertThatThrownBy(() -> getProfiler().execute("foo"))
             .isInstanceOf(SecurityException.class)
-            .hasMessageContaining("Execute commands are not permitted " +
-                                  "with this MBean. Please use unsafe MBean" +
-                                  "if they are needed. Command: foo");
+            .hasMessageContaining("The arbitrary command execution is not permitted with org.apache.cassandra.profiler:type=AsyncProfiler " +
+                                  "MBean backed by org.apache.cassandra.profiler.AsyncProfilerSafe class. " +
+                                  "If unsafe command execution is required, start Cassandra with ASYNC_PROFILER_UNSAFE_MODE " +
+                                  "property set to true. Rejected command: foo");
         }
     }
 }


### PR DESCRIPTION
    more fixes
    
    added documentation
    fixed nodetool help output tests
    added status command
    introduced binary download of files in fetch command if necessary
    hardened code
    ability to specify duration in human format (e.g. 5m)
    improved error parsing
    ability to execute purge, list and fetch even with disabled profiler
    async-profiler is disabled by default
    added nodetool tests
    add startup check checking kernel parameters
